### PR TITLE
Add support for dictionary look ups on macOS

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -11,7 +11,7 @@ export default class ContextMenuBuilder {
     this.debugMode = debugMode;
     this.menu = null;
   }
-  
+
   static setLogger(fn) {
     d = fn;
   }
@@ -201,6 +201,18 @@ export default class ContextMenuBuilder {
     let match = menuInfo.selectionText.match(/\w/);
     if (!match || match.length === 0) {
       return menu;
+    }
+
+    if (process.platform === 'darwin') {
+      let target = 'webContents' in this.windowOrWebView ?
+        this.windowOrWebView.webContents : this.windowOrWebView;
+
+      let lookUpDefinition = new MenuItem({
+        label: `Look Up “${menuInfo.selectionText}”`,
+        click: () => target.showDefinitionForSelection()
+      });
+
+      menu.append(lookUpDefinition);
     }
 
     let search = new MenuItem({


### PR DESCRIPTION
This PR adds an additional menu item, _Look Up "Word"_, available on text & text input fields. It simply uses the [`webContents.showDefinitionForSelection`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#webcontentsshowdefinitionforselection-macos) API.

IMPORTANT DEMO HERE: https://cl.ly/331B0y3U0P2l