### PR TITLE
Don’t log on sample detection error

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -302,7 +302,7 @@ export default class SpellCheckHandler {
     try {
       langWithoutLocale = await this.detectLanguageForText(inputText);
     } catch (e) {
-      d(`Couldn't detect language for text '${inputText}': ${e.message}, ignoring sample`);
+      d(`Couldn't detect language for text of length '${inputText.length}': ${e.message}, ignoring sample`);
       return;
     }
 


### PR DESCRIPTION
Upon more reflection, it was decided that messages should never be in the logs, ever (even if there's an error). 🙅 