### PR TITLE
Do not add seperator if src url is empty

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -129,9 +129,11 @@ export default class ContextMenuBuilder {
     menu.append(copyLink);
     menu.append(openLink);
 
-    this.addSeparator(menu);
+    if (this.isSrcUrlValid(menuInfo)) {
+      this.addSeparator(menu);
+      this.addImageItems(menu, menuInfo);
+    }
 
-    this.addImageItems(menu, menuInfo);
     this.addInspectElement(menu, menuInfo);
 
     return menu;
@@ -160,7 +162,9 @@ export default class ContextMenuBuilder {
   buildMenuForImage(menuInfo) {
     let menu = new Menu();
 
-    this.addImageItems(menu, menuInfo);
+    if (this.isSrcUrlValid(menuInfo)) {
+      this.addImageItems(menu, menuInfo);
+    }
     this.addInspectElement(menu, menuInfo);
     return menu;
   }
@@ -264,14 +268,14 @@ export default class ContextMenuBuilder {
     return menu;
   }
 
+  isSrcUrlValid(menuInfo) {
+    return menuInfo.srcUrl && menuInfo.srcURL.length > 0;
+  }
+
   /**
    * Adds "Copy Image" and "Copy Image URL" items when `src` is valid.
    */
   addImageItems(menu, menuInfo) {
-    if (!menuInfo.srcURL || menuInfo.srcURL.length === 0) {
-      return menu;
-    }
-
     let copyImage = new MenuItem({
       label: 'Copy Image',
       click: () => this.convertImageToBase64(menuInfo.srcURL,


### PR DESCRIPTION
This PR updates behavior of context menu builder to not to add separators if src url for image is not valid and no menu items appended after like attached screenshot.

![screen shot 2016-10-05 at 10 36 16](https://cloud.githubusercontent.com/assets/1210596/19124347/af462b52-8ae7-11e6-831d-6aa82158410c.png)
