### PR TITLE
Correct urlvalidation for menuinfo

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -269,7 +269,7 @@ export default class ContextMenuBuilder {
   }
 
   isSrcUrlValid(menuInfo) {
-    return menuInfo.srcUrl && menuInfo.srcURL.length > 0;
+    return menuInfo.srcURL && menuInfo.srcURL.length > 0;
   }
 
   /**


### PR DESCRIPTION
This PR amends typo in `isSrcUrlValid` which prevents validation correctly working. :/