### PR TITLE
Dedup thrashing spellcheck calls

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -123,7 +123,7 @@ export default class SpellCheckHandler {
     this.spellCheckInvoked = new Subject();
     this.spellingErrorOccurred = new Subject();
     this.isMisspelledCache = new LRU({
-      max: 32,
+      max: 512,
       maxAge: 8 * 1000
     });
 

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -429,7 +429,7 @@ export default class SpellCheckHandler {
     if (!this.currentSpellchecker) return true;
 
     if (process.platform === 'darwin') {
-      return !this.currentSpellchecker.isMisspelled(text);
+      return !this.isMisspelled(text);
     }
 
     this.spellCheckInvoked.next(true);


### PR DESCRIPTION
In certain scenarios such as when you move the selection over a word quickly, Electron will call out to the spellcheck handler over and over for the same word. 

## TODO:

- [x] Code Review