### PR TITLE
Support custom items in context menu

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -20,12 +20,14 @@ export default class ContextMenuBuilder {
    *                                                recommendations for.
    * @param  {BrowserWindow|WebView} windowOrWebView  The hosting window/WebView
    * @param  {Boolean} debugMode    If true, display the "Inspect Element" menu item.
+   * @param  {function} processMenu If passed, this method will be passed the menu to change
+   *                                it prior to display. Signature: (menu, info) => menu
    */
-  constructor(spellCheckHandler, windowOrWebView=null, debugMode=false, additionalItems = []) {
+  constructor(spellCheckHandler, windowOrWebView=null, debugMode=false, processMenu=(m) => m) {
     this.spellCheckHandler = spellCheckHandler;
     this.windowOrWebView = windowOrWebView || remote.getCurrentWindow();
     this.debugMode = debugMode;
-    this.additionalItems = additionalItems;
+    this.processMenu = processMenu;
     this.menu = null;
   }
 
@@ -97,7 +99,7 @@ export default class ContextMenuBuilder {
     this.addCopy(menu, menuInfo);
     this.addPaste(menu, menuInfo);
     this.addInspectElement(menu, menuInfo);
-    this.addAdditionalItems(menu);
+    this.processMenu(menu);
 
     return menu;
   }
@@ -137,7 +139,6 @@ export default class ContextMenuBuilder {
     }
 
     this.addInspectElement(menu, menuInfo);
-    this.addAdditionalItems(menu);
 
     return menu;
   }
@@ -153,7 +154,6 @@ export default class ContextMenuBuilder {
     this.addSearchItems(menu, menuInfo);
     this.addCopy(menu, menuInfo);
     this.addInspectElement(menu, menuInfo);
-    this.addAdditionalItems(menu);
 
     return menu;
   }
@@ -170,7 +170,6 @@ export default class ContextMenuBuilder {
       this.addImageItems(menu, menuInfo);
     }
     this.addInspectElement(menu, menuInfo);
-    this.addAdditionalItems(menu);
     return menu;
   }
 
@@ -373,30 +372,6 @@ export default class ContextMenuBuilder {
     });
 
     menu.append(inspect);
-    return menu;
-  }
-
-  /**
-   * Adds additional items to the menu
-   */
-  addAdditionalItems(menu) {
-    this.additionalItems.forEach((item) => {
-      if (!item.menuItem) {
-        return d(`Additional item did not contain menuItem property`);
-      }
-
-      if (item.condition !== undefined && (!item.condition ||
-        (typeof item.condition === 'function' && !item.condition()))) {
-        return menu;
-      }
-
-      if (typeof item.position === 'number') {
-        menu.insert(item.position, item.menuItem);
-      } else if (item.position === 'append') {
-        menu.append(item.menuItem);
-      }
-    });
-
     return menu;
   }
 

--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -385,7 +385,12 @@ export default class ContextMenuBuilder {
         return d(`Additional item did not contain menuItem property`);
       }
 
-      if (typeof item.position === Number) {
+      if (item.condition !== undefined && (!item.condition ||
+        (typeof item.condition === 'function' && !item.condition()))) {
+        return menu;
+      }
+
+      if (typeof item.position === 'number') {
         menu.insert(item.position, item.menuItem);
       } else if (item.position === 'append') {
         menu.append(item.menuItem);

--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -21,10 +21,11 @@ export default class ContextMenuBuilder {
    * @param  {BrowserWindow|WebView} windowOrWebView  The hosting window/WebView
    * @param  {Boolean} debugMode    If true, display the "Inspect Element" menu item.
    */
-  constructor(spellCheckHandler, windowOrWebView=null, debugMode=false) {
+  constructor(spellCheckHandler, windowOrWebView=null, debugMode=false, additionalItems = []) {
     this.spellCheckHandler = spellCheckHandler;
     this.windowOrWebView = windowOrWebView || remote.getCurrentWindow();
     this.debugMode = debugMode;
+    this.additionalItems = additionalItems;
     this.menu = null;
   }
 
@@ -96,6 +97,7 @@ export default class ContextMenuBuilder {
     this.addCopy(menu, menuInfo);
     this.addPaste(menu, menuInfo);
     this.addInspectElement(menu, menuInfo);
+    this.addAdditionalItems(menu);
 
     return menu;
   }
@@ -135,6 +137,7 @@ export default class ContextMenuBuilder {
     }
 
     this.addInspectElement(menu, menuInfo);
+    this.addAdditionalItems(menu);
 
     return menu;
   }
@@ -150,6 +153,7 @@ export default class ContextMenuBuilder {
     this.addSearchItems(menu, menuInfo);
     this.addCopy(menu, menuInfo);
     this.addInspectElement(menu, menuInfo);
+    this.addAdditionalItems(menu);
 
     return menu;
   }
@@ -166,6 +170,7 @@ export default class ContextMenuBuilder {
       this.addImageItems(menu, menuInfo);
     }
     this.addInspectElement(menu, menuInfo);
+    this.addAdditionalItems(menu);
     return menu;
   }
 
@@ -368,6 +373,25 @@ export default class ContextMenuBuilder {
     });
 
     menu.append(inspect);
+    return menu;
+  }
+
+  /**
+   * Adds additional items to the menu
+   */
+  addAdditionalItems(menu) {
+    this.additionalItems.forEach((item) => {
+      if (!item.menuItem) {
+        return d(`Additional item did not contain menuItem property`);
+      }
+
+      if (typeof item.position === Number) {
+        menu.insert(item.position, item.menuItem);
+      } else if (item.position === 'append') {
+        menu.append(item.menuItem);
+      }
+    });
+
     return menu;
   }
 


### PR DESCRIPTION
The current `contextMenuBuilder` is pretty damn good, but let's say you want to add just one more field (for instance `Exit Fullscreen`, you'd have to go back to building your own). 

This adds the ability to add custom `MenuItems`. No breaking change.